### PR TITLE
Update Workflow Permissions to apply least privilege principle

### DIFF
--- a/.github/workflows/docker-azure-function.yml
+++ b/.github/workflows/docker-azure-function.yml
@@ -1,9 +1,11 @@
 name: Docker Image CI
-
 on:
   push:
     branches:
     - master
+
+permissions: # Sets workflow permissions using the least privilege principle
+  contents: read # Read access to repo, required by the actions/checkout@v2 action
 
 jobs:
 

--- a/.github/workflows/docker-image-web-ui.yml
+++ b/.github/workflows/docker-image-web-ui.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - master
 
+permissions: # Sets workflow permissions using the least privilege principle
+  contents: read # Read access to repo, required by the actions/checkout@v2 action
+  
 jobs:
 
   build:


### PR DESCRIPTION
This commit modifies the permissions of the GITHUB_TOKEN for two GitHub Action workflows in the repository. The GITHUB_TOKEN is a special token that GitHub creates to authenticate GitHub Actions which by default has read/write access across several features of the repository.

The workflows only need 'contents: read' permission, which lets the GITHUB_TOKEN read the repo files during the action "actions/checkout@v2". This change addresses compliance with the [GitHub Action Permission Changes](https://docs.opensource.microsoft.com/github/apps/permission-changes/) by applying the least privilege principle. It reduces the risk of exposing or abusing the token, and helps in protecting the integrity of the repository and its contents.