### PR TITLE
Azure openai options

### DIFF
--- a/.github/workflows/docker-azure-function.yml
+++ b/.github/workflows/docker-azure-function.yml
@@ -1,9 +1,11 @@
 name: Docker Image CI
-
 on:
   push:
     branches:
     - master
+
+permissions: # Sets workflow permissions using the least privilege principle
+  contents: read # Read access to repo, required by the actions/checkout@v2 action
 
 jobs:
 

--- a/.github/workflows/docker-image-web-ui.yml
+++ b/.github/workflows/docker-image-web-ui.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - master
 
+permissions: # Sets workflow permissions using the least privilege principle
+  contents: read # Read access to repo, required by the actions/checkout@v2 action
+  
 jobs:
 
   build:

--- a/infrastructure/ARM/deployment-template.json
+++ b/infrastructure/ARM/deployment-template.json
@@ -2,6 +2,16 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "openAIFunctionName":{
+            "type": "string"
+        },
+        "newOrExistingOpenAIResource":{
+            "type": "string",
+            "allowedValues" : [
+                "new",
+                "existing"
+            ]
+        },
         "resourceGroupName": {
             "defaultValue": "[resourceGroup().name]",
             "type": "string"
@@ -286,7 +296,6 @@
         }
     },
     "variables": {
-        "openAIFunctionName": "[concat(parameters('functionName'),'-openai')]",
         "clientKey": "[concat(uniqueString(guid(resourceGroup().id, deployment().name)), parameters('newGuid'), 'Tg2%')]"
     },
     "resources": [
@@ -810,6 +819,7 @@
             }
         },
         {
+            "condition": "[equals(parameters('newOrExistingOpenAIResource'), 'new')]",
             "apiVersion": "2018-11-01",
             "name": "[parameters('openAIFunctionName')]",
             "type": "Microsoft.Web/sites",

--- a/infrastructure/ARM/deployment-template.json
+++ b/infrastructure/ARM/deployment-template.json
@@ -704,7 +704,7 @@
             "kind": "string",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites', parameters('functionName'))]",
-                "[resourceId('Microsoft.Web/sites', variables('openAIFunctionName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('openAIFunctionName'))]",
                 "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
             ],
             "properties": {
@@ -736,7 +736,7 @@
                 "WEBSITE_RUN_FROM_PACKAGE": "https://github.com/microsoft/Customer-Service-Conversational-Insights-with-Azure-OpenAI-Services/raw/master/infrastructure/deploy/csci-audio-dep.zip",
                 "function_name": "[parameters('functionName')]",
                 "function_key": "[variables('clientKey')]",
-                "openai_function_name": "[variables('openAIFunctionName')]",
+                "openai_function_name": "[parameters('openAIFunctionName')]",
                 "openai_function_key": "[variables('clientKey')]",
                 "deployment_type": "audio",
                 "OPENAI_PROMPT_KEYS": "[parameters('OPENAI_PROMPT_KEYS')]",
@@ -799,9 +799,9 @@
         {
             "type": "Microsoft.Web/sites/host/functionKeys",
             "apiVersion": "2018-11-01",
-            "name": "[concat(variables('openAIFunctionName'), '/default/clientKey')]",
+            "name": "[concat(parameters('openAIFunctionName'), '/default/clientKey')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('openAIFunctionName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('openAIFunctionName'))]",
                 "WaitFunctionDeploymentSection"
             ],
             "properties": {
@@ -811,7 +811,7 @@
         },
         {
             "apiVersion": "2018-11-01",
-            "name": "[variables('openAIFunctionName')]",
+            "name": "[parameters('openAIFunctionName')]",
             "type": "Microsoft.Web/sites",
             "kind": "functionapp,linux",
             "location": "[resourceGroup().location]",
@@ -822,7 +822,7 @@
                 "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusName'))]"
             ],
             "properties": {
-                "name": "[variables('openAIFunctionName')]",
+                "name": "[parameters('openAIFunctionName')]",
                 "siteConfig": {
                     "appSettings": [
                         {
@@ -930,7 +930,7 @@
             "name": "WaitFunctionDeploymentSection",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('openAIFunctionName'))]"
+                "[resourceId('Microsoft.Web/sites', parameters('openAIFunctionName'))]"
             ],
             "properties": {
                 "azPowerShellVersion": "3.0",


### PR DESCRIPTION
This change is intended to allow users to create a new Azure OpenAI resource during their deployment process, instead of using a pre-existing one. The parameter value determines whether a new resource is created or not. If the value is new, a new resource is created. Otherwise, an existing one is used. This is a draft PR because the target (dev) branch has diverged significantly from the upstream repository. This conflict will need to be resolved, and the changes made will need to be tested.