### PR TITLE
User-Controlled Azure OpenAI Deployment Options

### DIFF
--- a/infrastructure/ARM/deployment-template.json
+++ b/infrastructure/ARM/deployment-template.json
@@ -2,6 +2,16 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
   "parameters": {
+    "openAIFunctionName":{
+      "type": "string"
+    },
+    "newOrExistingOpenAIResource":{
+      "type": "string",
+      "allowedValues" : [
+          "new",
+          "existing"
+      ]
+    },
     "resourceGroupName": {
       "defaultValue": "[resourceGroup().name]",
       "type": "string"
@@ -301,7 +311,6 @@
     }
   },
     "variables": {
-        "openAIFunctionName": "[concat(parameters('functionName'),'-openai')]",
         "clientKey": "[concat(uniqueString(guid(resourceGroup().id, deployment().name)), parameters('newGuid'), 'Tg2%')]"
     },
     "resources": [
@@ -719,7 +728,7 @@
             "kind": "string",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites', parameters('functionName'))]",
-                "[resourceId('Microsoft.Web/sites', variables('openAIFunctionName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('openAIFunctionName'))]",
                 "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
             ],
             "properties": {
@@ -816,7 +825,7 @@
             "apiVersion": "2018-11-01",
             "name": "[concat(variables('openAIFunctionName'), '/default/clientKey')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('openAIFunctionName'))]",
+                "[resourceId('Microsoft.Web/sites', parameters('openAIFunctionName'))]",
                 "WaitFunctionDeploymentSection"
             ],
             "properties": {
@@ -945,7 +954,7 @@
             "name": "WaitFunctionDeploymentSection",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('openAIFunctionName'))]"
+                "[resourceId('Microsoft.Web/sites', parameters('openAIFunctionName'))]"
             ],
             "properties": {
                 "azPowerShellVersion": "3.0",


### PR DESCRIPTION
This change is intended to allow users to create a new Azure OpenAI resource during their deployment process, instead of using a pre-existing one. The parameter value determines whether a new resource is created or not. If the value is new, a new resource is created. Otherwise, an existing one is used. 

The PR is currently a Draft since changes made will need to be tested through a live deployment prior to merge.