### PR TITLE
fix: Linked Template for Cognitive Serach Services ARMTemplate json link updated and logic for isPathBase64Encoded updated

### DIFF
--- a/GBB.ConversationalKM.WebUI/CognitiveSearch.UI/Search/DocumentSearchClient.cs
+++ b/GBB.ConversationalKM.WebUI/CognitiveSearch.UI/Search/DocumentSearchClient.cs
@@ -84,7 +84,7 @@ namespace CognitiveSearch.UI
                 Schema = new SearchSchema().AddFields(_searchIndexClient.GetIndex(IndexName).Value.Fields);
                 Model = new SearchModel(Schema);
 
-                _isPathBase64Encoded = (configuration.GetSection("IsPathBase64Encoded")?.Value == "True");
+                _isPathBase64Encoded = (configuration.GetSection("IsPathBase64Encoded")?.Value.ToLower() == "true");
 
             }
             catch (Exception e)

--- a/infrastructure/ARM/deployment-template.json
+++ b/infrastructure/ARM/deployment-template.json
@@ -473,7 +473,7 @@
           "properties": {
               "mode": "Incremental",
               "templateLink": {
-                  "uri": "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-speech-sdk/master/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json",
+                  "uri": "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-speech-sdk/master/samples/ingestion/ingestion-client/infra/main.json",
                   "contentVersion": "1.0.0.0"
               },
               "parameters": {


### PR DESCRIPTION
Below file got removed/updated 2 weeks back in AzureSamples/CognitiveSearchServices SDK. So, updated

from /Setup/ArmTemplateBatch.json to ingestion-client/infra/main.json.